### PR TITLE
Adding attribute custom_template in Maps

### DIFF
--- a/geonode/maps/migrations/0027_map_custom_template.py
+++ b/geonode/maps/migrations/0027_map_custom_template.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('maps', '0026_map_content_map'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='map',
+            name='custom_template',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -136,6 +136,8 @@ class Map(ResourceBase, GXPMapBase):
         max_length=255,
         blank=True)
     # Full URL for featured map view, ie http://domain/someview
+    custom_template = models.TextField (blank=True, null= True)
+    
 
     def __unicode__(self):
         return '%s by %s' % (


### PR DESCRIPTION
## What does this PR do?

So, we added attribute called `custom_template`, where are we going to save the changes in css for our custom template. Then, this variable will be read by a template to be later rendered with original HTLM and CSS. 